### PR TITLE
Fix regular expression used to extract IDs

### DIFF
--- a/Example/Ono Tests/ONOXMLTests.m
+++ b/Example/Ono Tests/ONOXMLTests.m
@@ -22,6 +22,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import "Ono.h"
+
 @interface ONOXMLTests : XCTestCase
 
 @end
@@ -30,6 +32,11 @@
 
 - (void)setUp {
     [super setUp];
+}
+
+- (void)testCSSToXpath {
+    NSString *path = ONOXPathFromCSS(@"#some-composed-id h3");
+    XCTAssertEqualObjects(@"//[@id = 'some-composed-id']/h3", path, @"Created Xpath should be '//[@id = 'some-composed-id']/h3'");
 }
 
 @end

--- a/Ono/ONOXMLDocument.h
+++ b/Ono/ONOXMLDocument.h
@@ -22,6 +22,8 @@
 
 #import <Foundation/Foundation.h>
 
+NSString * ONOXPathFromCSS(NSString *CSS);
+
 @class ONOXMLElement;
 
 /**

--- a/Ono/ONOXMLDocument.m
+++ b/Ono/ONOXMLDocument.m
@@ -52,7 +52,8 @@ NSString * ONOXPathFromCSS(NSString *CSS) {
                         
                         {
                             NSError *error = nil;
-                            NSRegularExpression *idRegularExpression = [NSRegularExpression regularExpressionWithPattern:@"\\#(\\w+)" options:0 error:&error];
+                            NSRegularExpression *idRegularExpression = [NSRegularExpression regularExpressionWithPattern:@"\\#([\\w-]+)" options:0 error:&error];
+
                             NSTextCheckingResult *result = [idRegularExpression firstMatchInString:CSS options:0 range:range];
                             if ([result numberOfRanges] > 1) {
                                 [mutableXPathComponent appendFormat:@"[@id = '%@']", [token substringWithRange:[result rangeAtIndex:1]]];


### PR DESCRIPTION
I ran into an issue when I tried to fetch content using a CSS selector and the `enumerateElementsWithCSS:block:` method. 

On this page : http://en.wikipedia.org/wiki/List_of_spells_in_Harry_Potter
The selector : `div#mw-content-text h3` was generating `//div[@id = 'mw']/h3`

This PR simply adds dash ("-") as a valid component, but as the valid syntax for a valid XML/HTML attribute is much more complex (according to [this page](http://www.w3.org/TR/REC-xml/#sec-common-syn)), this may need more work at some point.

It also makes `ONOXPathFromCSS` public so it can be tested, but I'm not really sure about that part.
