### PR TITLE
Fix CSS descendant combinator selector problem

### DIFF
--- a/Example/Ono Tests/ONOCSSTests.m
+++ b/Example/Ono Tests/ONOCSSTests.m
@@ -52,8 +52,8 @@ extern NSString * ONOXPathFromCSS(NSString *CSS);
     XCTAssertEqualObjects(ONOXPathFromCSS(@"html *"), @"//html//*");
 }
 
-- (void)testCSSChildSelector {
-    XCTAssertEqualObjects(ONOXPathFromCSS(@"html body"), @"//html/body");
+- (void)testCSSDescendantCombinatorSelector {
+    XCTAssertEqualObjects(ONOXPathFromCSS(@"body p"), @"//body/descendant::p");
 }
 
 - (void)testCSSChildCombinatorSelector {

--- a/Ono/ONOXMLDocument.m
+++ b/Ono/ONOXMLDocument.m
@@ -43,6 +43,10 @@ NSString * ONOXPathFromCSS(NSString *CSS) {
                 } else if ([token isEqualToString:@"~"]) {
                     prefix = @"following-sibling::";
                 } else {
+                    if (!prefix && idx != 0) {
+                        prefix = @"descendant::";
+                    }
+
                     NSRange symbolRange = [token rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"#.[]"]];
                     if (symbolRange.location != NSNotFound) {
                         NSMutableString *mutableXPathComponent = [NSMutableString stringWithString:[token substringToIndex:symbolRange.location]];


### PR DESCRIPTION
CSS selector `body p` should translate to XPath `//body/descendant::p`
Space between two elements represents descendant relationship.
http://www.w3.org/TR/selectors/#descendant-combinators
