### PR TITLE
Cache regular expressions

### DIFF
--- a/Ono/ONOXMLDocument.m
+++ b/Ono/ONOXMLDocument.m
@@ -44,7 +44,7 @@ NSRegularExpression * ONOClassRegularExpression() {
 	return expression;
 }
 
-NSRegularExpression *ONOAttributeRegularExpression() {
+NSRegularExpression * ONOAttributeRegularExpression() {
 	static NSRegularExpression *expression = nil;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{


### PR DESCRIPTION
Regular expressions need to be compiled before they are used. Compiling them on every loop iteration is unnecessary since it's always the same set of regex's that are being used.

I also noticed that the `error` was being passed into `-regularExpressionWithPattern:options:error` but not being handled anywhere. In my opinion, handling this error is unnecessary because the regex patterns are constant and it's reasonable to assume that there would never be an error in compiling them. Seems like it would only be applicable to dynamically constructed patterns.
