### PR TITLE
fix bug in Ono and add test

### DIFF
--- a/Example/Ono Tests/ONOCSSTests.m
+++ b/Example/Ono Tests/ONOCSSTests.m
@@ -44,8 +44,12 @@ extern NSString * ONOXPathFromCSS(NSString *CSS);
     XCTAssertEqualObjects(ONOXPathFromCSS(@"span.highlighted"), @"//span[contains(concat(' ',normalize-space(@class),' '),' highlighted ')]");
 }
 
-- (void)testCSSIDSelector {
+- (void)testCSSElementAndIDSelector {
     XCTAssertEqualObjects(ONOXPathFromCSS(@"h1#logo"), @"//h1[@id = 'logo']");
+}
+
+- (void)testCSSIDSelector {
+    XCTAssertEqualObjects(ONOXPathFromCSS(@"#logo"), @"//*[@id = 'logo']");
 }
 
 - (void)testCSSWildcardChildSelector {

--- a/Example/Ono Tests/ONOHTMLTests.m
+++ b/Example/Ono Tests/ONOHTMLTests.m
@@ -58,7 +58,7 @@
 - (void)testTitleXPath {
     NSUInteger idx = 0;
     for (ONOXMLElement *element in [self.document XPath:@"//head/title"]) {
-        XCTAssertTrue(idx == 0, @"more than one  element found");
+        XCTAssertTrue(idx == 0, @"more than one element found");
         XCTAssertEqualObjects([element stringValue], @"mattt/Ono", @"title mismatch");
         idx++;
     }
@@ -68,8 +68,18 @@
 - (void)testTitleCSS {
     NSUInteger idx = 0;
     for (ONOXMLElement *element in [self.document CSS:@"head title"]) {
-        XCTAssertTrue(idx == 0, @"more than one  element found");
+        XCTAssertTrue(idx == 0, @"more than one element found");
         XCTAssertEqualObjects([element stringValue], @"mattt/Ono", @"title mismatch");
+        idx++;
+    }
+    XCTAssertTrue(idx == 1, @"fewer than one element found");
+}
+
+- (void)testIdCss {
+    NSUInteger idx = 0;
+    for (ONOXMLElement *element in [self.document CSS:@"#account_settings"]) {
+        XCTAssertTrue(idx == 0, @"more than one element found");
+        XCTAssertEqualObjects(element[@"href"], @"/settings/profile", @"href mismatch");
         idx++;
     }
     XCTAssertTrue(idx == 1, @"fewer than one element found");

--- a/Ono/ONOXMLDocument.m
+++ b/Ono/ONOXMLDocument.m
@@ -86,7 +86,7 @@ NSString * ONOXPathFromCSS(NSString *CSS) {
                             NSRegularExpression *idRegularExpression = ONOIdRegularExpression();
                             NSTextCheckingResult *result = [idRegularExpression firstMatchInString:CSS options:0 range:range];
                             if ([result numberOfRanges] > 1) {
-                                [mutableXPathComponent appendFormat:@"[@id = '%@']", [token substringWithRange:[result rangeAtIndex:1]]];
+                                [mutableXPathComponent appendFormat:@"%@[@id = '%@']", (symbolRange.location == 0) ? @"*" : @"", [token substringWithRange:[result rangeAtIndex:1]]];
                             }
                         }
 


### PR DESCRIPTION
@mattt I was having problem with the CSS selector #foo where in my document I had 

```
<img id="foo" src="...">
```

I was getting:

```
XPath error : Invalid expression
//[@id = 'foo']
  ^
```

From http://ejohn.org/blog/xpath-css-selectors/

Looks like this is supposed to be:

```
//*[@id = 'foo']
```

And when I fix that, it works.  I've added a test for this, and all tests pass.

But I'm no XPath expert, so please let me know what you think.
