### PR TITLE
Added blocked based enumeration methods that can be stopped and have an index parameter

### DIFF
--- a/Example/main.m
+++ b/Example/main.m
@@ -63,9 +63,8 @@ int main(int argc, const char * argv[]) {
         XPath = @"//food/name";
         NSLog(@"XPath Search: %@", XPath);
         __block ONOXMLElement *blockElement = nil;
-        __block NSUInteger count = 0;
-        [document enumerateElementsWithXPath:XPath stoppableBlock:^(ONOXMLElement *element, BOOL *stop) {
-            *stop = count++ == 1;
+        [document enumerateElementsWithXPath:XPath stoppableBlock:^(ONOXMLElement *element, NSUInteger idx, BOOL *stop) {
+            *stop = idx == 1;
             if (*stop) {
                 blockElement = element;
             }

--- a/Ono/ONOXMLDocument.h
+++ b/Ono/ONOXMLDocument.h
@@ -58,12 +58,13 @@
  Enumerate elements matching an XPath selector.
  
  @param XPath The XPath selector
- @param block A block that is executed for each result. This block has no return value and takes two arguments:
+ @param block A block that is executed for each result. This block has no return value and takes three arguments:
     element: the enumerated element.
+    idx: the index of the current item.
     stop: the block can set the value to `YES` to stop further processing of the elements. The stop argument is an out-only argument. You should only ever set this BOOL to `YES` within the block.
  */
 - (void)enumerateElementsWithXPath:(NSString *)XPath
-                             stoppableBlock:(void (^)(ONOXMLElement *element, BOOL *stop))block;
+                             stoppableBlock:(void (^)(ONOXMLElement *element, NSUInteger idx, BOOL *stop))block;
 
 /**
  Returns the first elements matching an XPath selector, or `nil` if there are no results.
@@ -100,12 +101,13 @@
  Enumerate elements matching a CSS selector.
  
  @param CSS The CSS selector
- @param block A block that is executed for each result. This block has no return value and takes two arguments:
+ @param block A block that is executed for each result. This block has no return value and takes three arguments:
     element: the enumerated element.
+    idx: the index of the current item.
     stop: the block can set the value to `YES` to stop further processing of the elements. The stop argument is an out-only argument. You should only ever set this BOOL to `YES` within the block.
  */
 - (void)enumerateElementsWithCSS:(NSString *)CSS
-                           stoppableBlock:(void (^)(ONOXMLElement *element, BOOL *stop))block;
+                           stoppableBlock:(void (^)(ONOXMLElement *element, NSUInteger idx, BOOL *stop))block;
 
 /**
  Returns the first elements matching a CSS selector, or `nil` if there are no results.

--- a/Ono/ONOXMLDocument.m
+++ b/Ono/ONOXMLDocument.m
@@ -320,7 +320,7 @@ static BOOL ONOXMLNodeMatchesTagInNamespace(xmlNodePtr node, NSString *tag, NSSt
     [self.rootElement enumerateElementsWithXPath:XPath block:block];
 }
 
-- (void)enumerateElementsWithXPath:(NSString *)XPath stoppableBlock:(void (^)(ONOXMLElement *, BOOL *))block
+- (void)enumerateElementsWithXPath:(NSString *)XPath stoppableBlock:(void (^)(ONOXMLElement *, NSUInteger, BOOL *))block
 {
     [self.rootElement enumerateElementsWithXPath:XPath stoppableBlock:block];
 }
@@ -340,7 +340,7 @@ static BOOL ONOXMLNodeMatchesTagInNamespace(xmlNodePtr node, NSString *tag, NSSt
     [self.rootElement enumerateElementsWithCSS:CSS block:block];
 }
 
-- (void)enumerateElementsWithCSS:(NSString *)CSS stoppableBlock:(void (^)(ONOXMLElement *, BOOL *))block
+- (void)enumerateElementsWithCSS:(NSString *)CSS stoppableBlock:(void (^)(ONOXMLElement *, NSUInteger, BOOL *))block
 {
     [self.rootElement enumerateElementsWithCSS:CSS stoppableBlock:block];
 }
@@ -688,20 +688,21 @@ static BOOL ONOXMLNodeMatchesTagInNamespace(xmlNodePtr node, NSString *tag, NSSt
         return;
     }
 
-    [self enumerateElementsWithXPath:XPath stoppableBlock:^(ONOXMLElement *element, BOOL *stop) {
+    [self enumerateElementsWithXPath:XPath stoppableBlock:^(ONOXMLElement *element, NSUInteger idx, BOOL *stop) {
         block(element);
     }];
 }
 
-- (void)enumerateElementsWithXPath:(NSString *)XPath stoppableBlock:(void (^)(ONOXMLElement *, BOOL *))block
+- (void)enumerateElementsWithXPath:(NSString *)XPath stoppableBlock:(void (^)(ONOXMLElement *, NSUInteger, BOOL *))block
 {
     if (!block) {
         return;
     }
     
+    NSUInteger currentIndex = 0;
     for (ONOXMLElement *element in [self XPath:XPath]) {
         BOOL stop = NO;
-        block(element, &stop);
+        block(element, currentIndex++, &stop);
         if (stop) {
             break;
         }
@@ -726,7 +727,7 @@ static BOOL ONOXMLNodeMatchesTagInNamespace(xmlNodePtr node, NSString *tag, NSSt
     [self enumerateElementsWithXPath:ONOXPathFromCSS(CSS) block:block];
 }
 
-- (void)enumerateElementsWithCSS:(NSString *)CSS stoppableBlock:(void (^)(ONOXMLElement *, BOOL *))block
+- (void)enumerateElementsWithCSS:(NSString *)CSS stoppableBlock:(void (^)(ONOXMLElement *, NSUInteger, BOOL *))block
 {
     [self enumerateElementsWithXPath:ONOXPathFromCSS(CSS) stoppableBlock:block];
 }


### PR DESCRIPTION
Added 2 methods that provide the enumeration pattern similar to that of `NSArray`s blocked based enumeration. This then allows the enumeration to be stopped whenever needed. This is useful if you only want the first element in the XPath query.
