### PR TITLE
Define prefix for default namespace and support XPath function result

### DIFF
--- a/Example/Ono Example.xcodeproj/project.pbxproj
+++ b/Example/Ono Example.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		3D4BE0B41902F4F700F99600 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F897F98F18BFC5860043A736 /* libxml2.dylib */; };
 		8DE24971197702E60093D6A0 /* ONOVMAPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */; };
 		8DE24972197702F10093D6A0 /* vmap.xml in Resources */ = {isa = PBXBuildFile; fileRef = 8DE2496E1977028F0093D6A0 /* vmap.xml */; };
+		E0ECA13F1A5A42EE00922C7F /* ocf.xml in Resources */ = {isa = PBXBuildFile; fileRef = E0ECA13E1A5A42EE00922C7F /* ocf.xml */; };
+		E0ECA1411A5A434500922C7F /* ONODefaultNamespaceXPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */; };
 		F8301EA218CF1E4600085EC9 /* web.html in Resources */ = {isa = PBXBuildFile; fileRef = F8301EA118CF1E4600085EC9 /* web.html */; };
 		F8301EA518CF1E5700085EC9 /* ONOHTMLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F8301EA418CF1E5700085EC9 /* ONOHTMLTests.m */; };
 		F87981311944D5C800D73412 /* xml.xml in Resources */ = {isa = PBXBuildFile; fileRef = F87981301944D5C800D73412 /* xml.xml */; };
@@ -51,6 +53,8 @@
 /* Begin PBXFileReference section */
 		8DE2496E1977028F0093D6A0 /* vmap.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vmap.xml; sourceTree = "<group>"; };
 		8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONOVMAPTests.m; sourceTree = "<group>"; };
+		E0ECA13E1A5A42EE00922C7F /* ocf.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = ocf.xml; sourceTree = "<group>"; };
+		E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONODefaultNamespaceXPathTests.m; sourceTree = "<group>"; };
 		F8301EA118CF1E4600085EC9 /* web.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = web.html; sourceTree = "<group>"; };
 		F8301EA418CF1E5700085EC9 /* ONOHTMLTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONOHTMLTests.m; sourceTree = "<group>"; };
 		F87981301944D5C800D73412 /* xml.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = xml.xml; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 		F897F99E18BFCC9A0043A736 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */,
 				8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */,
 				F897F9A418BFCC9A0043A736 /* ONOXMLTests.m */,
 				F897F9AE18BFCED00043A736 /* ONOAtomTests.m */,
@@ -192,6 +197,7 @@
 				F897F9AC18BFCEB60043A736 /* atom.xml */,
 				8DE2496E1977028F0093D6A0 /* vmap.xml */,
 				F87981301944D5C800D73412 /* xml.xml */,
+				E0ECA13E1A5A42EE00922C7F /* ocf.xml */,
 				F8301EA118CF1E4600085EC9 /* web.html */,
 			);
 			name = "Supporting Files";
@@ -273,6 +279,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F897F9AD18BFCEB60043A736 /* atom.xml in Resources */,
+				E0ECA13F1A5A42EE00922C7F /* ocf.xml in Resources */,
 				8DE24972197702F10093D6A0 /* vmap.xml in Resources */,
 				F897F9A318BFCC9A0043A736 /* InfoPlist.strings in Resources */,
 				F8301EA218CF1E4600085EC9 /* web.html in Resources */,
@@ -300,6 +307,7 @@
 				F8301EA518CF1E5700085EC9 /* ONOHTMLTests.m in Sources */,
 				F8DC5D9E18C78F9800D69DD8 /* ONOCSSTests.m in Sources */,
 				F897F9B118BFCFC20043A736 /* ONOXMLDocument.m in Sources */,
+				E0ECA1411A5A434500922C7F /* ONODefaultNamespaceXPathTests.m in Sources */,
 				F897F9A518BFCC9A0043A736 /* ONOXMLTests.m in Sources */,
 				F897F9AF18BFCED00043A736 /* ONOAtomTests.m in Sources */,
 			);

--- a/Example/Ono Example.xcodeproj/project.pbxproj
+++ b/Example/Ono Example.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3D4BE0B41902F4F700F99600 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F897F98F18BFC5860043A736 /* libxml2.dylib */; };
 		8DE24971197702E60093D6A0 /* ONOVMAPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */; };
 		8DE24972197702F10093D6A0 /* vmap.xml in Resources */ = {isa = PBXBuildFile; fileRef = 8DE2496E1977028F0093D6A0 /* vmap.xml */; };
+		E094802C1A5D187700014B72 /* ONOXPathFunctionResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E094802B1A5D187700014B72 /* ONOXPathFunctionResultTests.m */; };
 		E0ECA13F1A5A42EE00922C7F /* ocf.xml in Resources */ = {isa = PBXBuildFile; fileRef = E0ECA13E1A5A42EE00922C7F /* ocf.xml */; };
 		E0ECA1411A5A434500922C7F /* ONODefaultNamespaceXPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */; };
 		F8301EA218CF1E4600085EC9 /* web.html in Resources */ = {isa = PBXBuildFile; fileRef = F8301EA118CF1E4600085EC9 /* web.html */; };
@@ -53,6 +54,7 @@
 /* Begin PBXFileReference section */
 		8DE2496E1977028F0093D6A0 /* vmap.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vmap.xml; sourceTree = "<group>"; };
 		8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONOVMAPTests.m; sourceTree = "<group>"; };
+		E094802B1A5D187700014B72 /* ONOXPathFunctionResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONOXPathFunctionResultTests.m; sourceTree = "<group>"; };
 		E0ECA13E1A5A42EE00922C7F /* ocf.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = ocf.xml; sourceTree = "<group>"; };
 		E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ONODefaultNamespaceXPathTests.m; sourceTree = "<group>"; };
 		F8301EA118CF1E4600085EC9 /* web.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = web.html; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 		F897F99E18BFCC9A0043A736 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E094802B1A5D187700014B72 /* ONOXPathFunctionResultTests.m */,
 				E0ECA1401A5A434500922C7F /* ONODefaultNamespaceXPathTests.m */,
 				8DE2496F197702D90093D6A0 /* ONOVMAPTests.m */,
 				F897F9A418BFCC9A0043A736 /* ONOXMLTests.m */,
@@ -304,6 +307,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DE24971197702E60093D6A0 /* ONOVMAPTests.m in Sources */,
+				E094802C1A5D187700014B72 /* ONOXPathFunctionResultTests.m in Sources */,
 				F8301EA518CF1E5700085EC9 /* ONOHTMLTests.m in Sources */,
 				F8DC5D9E18C78F9800D69DD8 /* ONOCSSTests.m in Sources */,
 				F897F9B118BFCFC20043A736 /* ONOXMLDocument.m in Sources */,

--- a/Example/Ono Tests/ONODefaultNamespaceXPathTests.m
+++ b/Example/Ono Tests/ONODefaultNamespaceXPathTests.m
@@ -1,0 +1,58 @@
+//
+//  ONODefaultNamespaceXPathTests.m
+//  Ono Example
+//
+//  Created by CHEN Xian’an on 1/5/15.
+//  Copyright (c) 2015 Mattt Thompson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Ono.h"
+
+@interface ONODefaultNamespaceXPathTests : XCTestCase
+@property (nonatomic, strong) ONOXMLDocument *document;
+@end
+
+@implementation ONODefaultNamespaceXPathTests
+
+- (void)setUp {
+    [super setUp];
+    NSError *error = nil;
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"ocf" ofType:@"xml"];
+    self.document = [ONOXMLDocument XMLDocumentWithData:[NSData dataWithContentsOfFile:filePath] error:&error];
+    
+    XCTAssertNotNil(self.document, @"Document should not be nil");
+    XCTAssertNil(error, @"Error should not be generated");
+}
+
+#pragma mark -
+
+- (void)testAbsoluteXPathWithDefaultNamespace {
+    [self.document definePrefix:@"ocf" forDefaultNamespace:@"urn:oasis:names:tc:opendocument:xmlns:container"];
+    NSString *XPath = @"/ocf:container/ocf:rootfiles/ocf:rootfile";
+    NSUInteger count = 0;
+    for (ONOXMLElement *element in [self.document XPath:XPath]) {
+        XCTAssertEqualObjects(@"rootfile", element.tag, @"tag should be `rootfile`");
+        count++;
+    }
+    
+    XCTAssertEqual(1, count, @"Element should be found at XPath '%@'", XPath);
+}
+
+- (void)testRelativeXPathWithDefaultNamespace {
+    [self.document definePrefix:@"ocf" forDefaultNamespace:@"urn:oasis:names:tc:opendocument:xmlns:container"];
+    NSString *absXPath = @"/ocf:container/ocf:rootfiles";
+    NSString *relXPath = @"./ocf:rootfile";
+    NSUInteger count = 0;
+    for (ONOXMLElement *absElement in [self.document XPath:absXPath]) {
+        for (ONOXMLElement *relElement in [absElement XPath:relXPath]) {
+            XCTAssertEqualObjects(@"rootfile", relElement.tag, @"tag should be `rootfile`");
+            count++;
+        }
+    }
+    
+    XCTAssertEqual(1, count, @"Element should be found at XPath '%@' relative to XPath '%@'", relXPath, absXPath);
+}
+
+@end

--- a/Example/Ono Tests/ONOXPathFunctionResultTests.m
+++ b/Example/Ono Tests/ONOXPathFunctionResultTests.m
@@ -1,0 +1,49 @@
+//
+//  ONOXPathFunctionResultTests.m
+//  Ono Example
+//
+//  Created by CHEN Xian’an on 1/7/15.
+//  Copyright (c) 2015 Mattt Thompson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Ono.h"
+
+@interface ONOXPathFunctionResultTests : XCTestCase
+@property (nonatomic, strong) ONOXMLDocument *document;
+@end
+
+@implementation ONOXPathFunctionResultTests
+
+- (void)setUp {
+    [super setUp];
+    
+    NSError *error = nil;
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"atom" ofType:@"xml"];
+    self.document = [ONOXMLDocument XMLDocumentWithData:[NSData dataWithContentsOfFile:filePath] error:&error];
+    [self.document definePrefix:@"atom" forDefaultNamespace:@"http://www.w3.org/2005/Atom"];
+    
+    XCTAssertNotNil(self.document, @"Document should not be nil");
+    XCTAssertNil(error, @"Error should not be generated");
+}
+
+- (void)testFunctionResultBoolVaule {
+    NSString *XPath = @"starts-with('Ono','O')";
+    ONOXPathFunctionResult *result = [self.document.rootElement functionResultByEvaluatingXPath:XPath];
+    XCTAssertTrue(result.boolValue, "Result boolVaule should be true");
+}
+
+- (void)testFunctionResultNumericValue {
+    NSString *XPath = @"count(./atom:link)";
+    ONOXPathFunctionResult *result = [self.document.rootElement functionResultByEvaluatingXPath:XPath];
+    XCTAssertEqual(result.numericValue, 2, "Number of child links should be 2");
+}
+
+- (void)testFunctionResultStringVaule {
+    NSString *XPath = @"string(./atom:entry[1]/dc:language[1]/text())";
+    ONOXPathFunctionResult *result = [self.document.rootElement functionResultByEvaluatingXPath:XPath];
+    XCTAssertEqualObjects(result.stringValue, @"en-us", "Result stringValue should be `en-us`");
+}
+
+@end

--- a/Example/Ono Tests/ocf.xml
+++ b/Example/Ono Tests/ocf.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>

--- a/Ono/ONOXMLDocument.h
+++ b/Ono/ONOXMLDocument.h
@@ -217,6 +217,14 @@
 + (instancetype)HTMLDocumentWithData:(NSData *)data
                                error:(NSError * __autoreleasing *)error;
 
+/**
+ Define a prefix for XML document's default namespace. It's necessary for XPath query in XML document that contains only default namespace.
+ 
+ @param prefix The prefix name
+ @param nspace The default namespace URI that declared in XML Document
+ */
+- (void)definePrefix:(NSString *)prefix forDefaultNamespace:(NSString *)nspace;
+
 @end
 
 #pragma mark -

--- a/Ono/ONOXMLDocument.h
+++ b/Ono/ONOXMLDocument.h
@@ -24,6 +24,8 @@
 
 @class ONOXMLElement;
 
+@class ONOXPathFunctionResult;
+
 /**
  The `ONOSearching` protocol is adopted by `ONOXMLDocument` and `ONOXMLElement`, denoting that they can search for elements using XPath or CSS selectors.
 
@@ -44,6 +46,15 @@
  @return An enumerable collection of results.
  */
 - (id <NSFastEnumeration>)XPath:(NSString *)XPath;
+
+/**
+ Returns the result for an XPath selector that contains XPath function.
+ 
+ @param XPath The XPath selector
+ 
+ @return The function result
+ */
+- (ONOXPathFunctionResult *)functionResultByEvaluatingXPath:(NSString *)XPath;
 
 /**
  @deprecated Use `enumerateElementsWithXPath:usingBlock:` instead
@@ -223,7 +234,8 @@
  @param prefix The prefix name
  @param nspace The default namespace URI that declared in XML Document
  */
-- (void)definePrefix:(NSString *)prefix forDefaultNamespace:(NSString *)nspace;
+- (void)definePrefix:(NSString *)prefix
+ forDefaultNamespace:(NSString *)nspace;
 
 @end
 
@@ -405,6 +417,27 @@
 
 @end
 
+/**
+ `ONOXPathFunctionResult` represents a XPath function result in an `ONOXPathFunctionResult`.
+ */
+@interface ONOXPathFunctionResult : NSObject
+
+/**
+ represents `boolval` in `xmlXPathObject`
+ */
+@property (readonly, nonatomic) BOOL boolValue;
+
+/**
+ represents `floatval` in `xmlXPathObject`
+ */
+@property (readonly, nonatomic) double numericValue;
+
+/**
+ represents `stringval` in `xmlXPathObject`
+ */
+@property (readonly, nonatomic, copy) NSString *stringValue;
+
+@end
 
 ///---------------------------
 /// @name Constants


### PR DESCRIPTION
To support XPath query in XML document that contains default namespace.

Also add support for XPath function result.

 Check the example in tests.