### PR TITLE
Added failing Atom XPath test

### DIFF
--- a/Example/Ono Tests/ONOAtomTests.m
+++ b/Example/Ono Tests/ONOAtomTests.m
@@ -64,6 +64,14 @@
     XCTAssertEqualObjects([titleElement stringValue], @"Example Feed", @"title string value should be 'Example Feed'");
 }
 
+- (void)testXPathTitle {
+    ONOXMLElement *titleElement = [self.document.rootElement firstChildWithXPath:@"/feed/title"];
+    
+    XCTAssertNotNil(titleElement, @"title element should not be nil");
+    XCTAssertEqualObjects(titleElement.tag, @"title", @"tag should be `title`");
+    XCTAssertEqualObjects([titleElement stringValue], @"Example Feed", @"title string value should be 'Example Feed'");
+}
+
 - (void)testLinks {
     NSArray *linkElements = [self.document.rootElement childrenWithTag:@"link"];
 


### PR DESCRIPTION
Related to #26 

I've added a test to use XPath to get the `title` element from the atom feed that currently fails. If `xmlns="http://www.w3.org/2005/Atom"` is removed from the XML then the test passes.

Pull request #25 might be related especially this commit 2a6a86de6c94d1a5e4f54bc9ce8e55778998bea3