### PR TITLE
Return error when document creation fails

### DIFF
--- a/Tests/ONOHTMLTests.m
+++ b/Tests/ONOHTMLTests.m
@@ -85,4 +85,11 @@
     XCTAssertTrue(idx == 1, @"fewer than one element found");
 }
 
+- (void)testReturnsErrorWithNilHTMLDocument {
+    NSError *error;
+    self.document = [ONOXMLDocument HTMLDocumentWithData:nil error:&error];
+    XCTAssertNotNil(error, @"error should not be nil");
+    XCTAssertNotNil(error.userInfo[NSLocalizedFailureReasonErrorKey], @"error should have a localized failure reason");
+}
+
 @end

--- a/Tests/ONOXMLTests.m
+++ b/Tests/ONOXMLTests.m
@@ -85,4 +85,11 @@
     XCTAssertEqual(headerElement.lineNumber, 123, @"header line number should be correct");
 }
 
+- (void)testReturnsErrorWithNilXMLDocument {
+    NSError *error;
+    self.document = [ONOXMLDocument XMLDocumentWithData:nil error:&error];
+    XCTAssertNotNil(error, @"error should not be nil");
+    XCTAssertNotNil(error.userInfo[NSLocalizedFailureReasonErrorKey], @"error should have a localized failure reason");
+}
+
 @end


### PR DESCRIPTION
This commit adds support for returning errors when creating an XML document fails.

Example error response description:

    Error Domain=com.ono.error.initialization Code=801 "The operation
    couldn’t be completed. Tag article invalid" UserInfo=0x7f8f0b402f20
    {NSLocalizedFailureReason=Tag article invalid}