### PR TITLE
Fix XPathFromCSS bug(general) & test case compile error(xcode 7)

### DIFF
--- a/Source/ONOXMLDocument.m
+++ b/Source/ONOXMLDocument.m
@@ -86,7 +86,7 @@ NSString * ONOXPathFromCSS(NSString *CSS) {
                         NSRange range = NSMakeRange(0, [token length]);
 
                         {
-                            NSTextCheckingResult *result = [ONOIdRegularExpression() firstMatchInString:CSS options:(NSMatchingOptions)0 range:range];
+                            NSTextCheckingResult *result = [ONOIdRegularExpression() firstMatchInString:token options:(NSMatchingOptions)0 range:range];
                             if ([result numberOfRanges] > 1) {
                                 [mutableXPathComponent appendFormat:@"%@[@id = '%@']", (symbolRange.location == 0) ? @"*" : @"", [token substringWithRange:[result rangeAtIndex:1]]];
                             }

--- a/Tests/ONOCSSTests.m
+++ b/Tests/ONOCSSTests.m
@@ -83,6 +83,10 @@ extern NSString * ONOXPathFromCSS(NSString *CSS);
     XCTAssertEqualObjects(ONOXPathFromCSS(@"img[alt]"), @".//img[@alt]");
 }
 
+- (void)testCSSCombinedSelector {
+    XCTAssertEqualObjects(ONOXPathFromCSS(@"div#test .note span:first-child"), @".//div[@id = 'test']/descendant::*[contains(concat(' ',normalize-space(@class),' '),' note ')]/descendant::span:first-child");
+}
+
 /*
 - (void)testCSSAttributeContainsValueSelector {
     XCTAssertEqualObjects(ONOXPathFromCSS(@"i[href~=\"icon\"]"), @"//i[contains(concat(' ', @class, ' '),concat(' ', 'icon', ' '))]");

--- a/Tests/ONOHTMLTests.m
+++ b/Tests/ONOHTMLTests.m
@@ -51,8 +51,8 @@
     NSArray *children = [self.document.rootElement children];
     XCTAssertNotNil(children, @"children should not be nil");
     XCTAssertTrue([children count] == 2, @"root element has more than two children");
-    XCTAssertEqualObjects([[children firstObject] tag], @"head", @"head not first child of html");
-    XCTAssertEqualObjects([[children lastObject] tag], @"body", @"body not last child of html");
+    XCTAssertEqualObjects([(ONOXMLElement*)[children firstObject] tag], @"head", @"head not first child of html");
+    XCTAssertEqualObjects([(ONOXMLElement*)[children lastObject] tag], @"body", @"body not last child of html");
 }
 
 - (void)testTitleXPath {


### PR DESCRIPTION
https://github.com/mattt/Ono/commit/002d2f2a80ad9ca1eded9f8ac894b2c69437dd39
Fixed a bug in XPathFromCSS that mistakenly matches the CSS string rather than token string, test case added for this bug.

https://github.com/mattt/Ono/commit/94f30a52239bd578cdf01814140e8c9fb954549a
Added explicit type cast to fix compilation error for test in Xcode 7 beta, where NSArray returns ObjectType element rather than id. This will not affect previous versions of Xcode. Please refer to 'Objective-C Language Features' in http://adcdownload.apple.com/Developer_Tools/Xcode_7_beta_4/Xcode_7_beta_4_Release_Notes.pdf
